### PR TITLE
Fixes #10. This make FAQ topic mobile responsive. 

### DIFF
--- a/src/app/assets/main.css
+++ b/src/app/assets/main.css
@@ -5928,6 +5928,15 @@ label {
   font-weight: 700;
   line-height: 200px; /* 100% */
   text-transform: uppercase;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+@media (max-width: 991px) {
+  .faq-big-text {
+    font-size: 115px;
+    line-height: 115px; /* 100% */
+  }
 }
 
 .agk-team .container-fluid {


### PR DESCRIPTION
FAQ topic previously overflew body, hence navbar had a larger width than body. Fixing this will fix navbar overflowing on mobile.